### PR TITLE
allow to specify children that are displayed while waiting

### DIFF
--- a/lib/Delay.js
+++ b/lib/Delay.js
@@ -159,7 +159,7 @@ var Delay = function (_Component) {
         return this.props.children;
       }
 
-      return null;
+      return this.props.childrenWaiting;
     }
   }]);
 
@@ -168,10 +168,12 @@ var Delay = function (_Component) {
 
 Delay.propTypes = {
   children: _propTypes2.default.node,
+  childrenWaiting: _propTypes2.default.node,
   wait: _propTypes2.default.number
 };
 Delay.defaultProps = {
-  wait: 250
+  wait: 250,
+  childrenWaiting: null
 };
 exports.default = Delay;
 

--- a/src/Delay.js
+++ b/src/Delay.js
@@ -4,11 +4,13 @@ import PropTypes from 'prop-types';
 class Delay extends Component {
   static propTypes = {
     children: PropTypes.node,
+    childrenWaiting: PropTypes.node,
     wait: PropTypes.number,
   };
 
   static defaultProps = {
     wait: 250,
+    childrenWaiting: null
   };
 
   state = {
@@ -32,7 +34,7 @@ class Delay extends Component {
       return this.props.children;
     }
 
-    return null;
+    return this.props.childrenWaiting;
   }
 }
 


### PR DESCRIPTION
new prop childrenWaiting

defaults to null.

if set, this will be rendered while waiting